### PR TITLE
added export to PDF with a given answer key

### DIFF
--- a/docs/export.md
+++ b/docs/export.md
@@ -22,3 +22,12 @@ You can export a RAT so that you can import it in [Supermark](https://falkr.gith
     rat export --format supermark --solution abcdabcdab questions.txt
 
 You need to provide the solution string to shuffle the answer alternatives. 
+
+
+## Exporting to PDF
+
+You can export a RAT so that you can use it as a simple PDF file with randomized answers.
+
+    rat export --format pdf --solution abcdabcdab questions.txt
+
+You need to provide the solution string to shuffle the answer alternatives. 

--- a/teampy/command_line_rat.py
+++ b/teampy/command_line_rat.py
@@ -610,7 +610,7 @@ def email(file, testonly):
 @rat.command()
 @click.argument("file", type=click.Path(exists=True))
 @click.option(
-    "--format", type=click.Choice(["blackboard", "supermark"], case_sensitive=False)
+    "--format", type=click.Choice(["blackboard", "supermark", "pdf"], case_sensitive=False)
 )
 @click.option(
     "--solution",
@@ -637,7 +637,14 @@ def export(file, format, solution):
         export_file_path = os.path.join(os.path.dirname(file), "rat.md")
         with open(export_file_path, "w", encoding="utf-8") as file:
             file.write(text)
-
+    elif format == "pdf":
+        latex = questionaire.write_pdf(solution)
+        export_file_path = os.path.join(os.path.dirname(file), "rat.pdf")
+        # empty directory for tex reasons...
+        current_dir = os.path.abspath(os.path.dirname(file))
+        pdf = build_pdf(latex, texinputs=[current_dir, ""])
+        pdf.save_to(export_file_path)
+ 
 
 if __name__ == "__main__":
     rat()

--- a/teampy/core.py
+++ b/teampy/core.py
@@ -375,11 +375,25 @@ class Questionaire:
             preamble = myfile.read()  # .replace('\n', '')
             lines.append(preamble)
         lines.append("\\subsubsection*{{RAT Test Run}}\n")
-        index = 0
         for q in self.questions:
-            index += 1
             key = random.choice(["a", "b", "c", "d"])
-            lines.append(q.write_latex(index, key))
+            lines.append(q.write_latex(q.number, key))
+        lines.append("\\end{document}")
+        return "".join(lines)
+
+    def write_pdf(self, solution):
+        lines = []
+        # add latex preamble
+        # abs_file_path = os.path.join(os.path.dirname(__file__), 'resources', 'latex_preamble.tex')
+        abs_file_path = os.path.join(os.path.dirname(__file__), "latex_preamble.tex")
+        with open(abs_file_path, "r", encoding="utf-8") as myfile:
+            preamble = myfile.read()  # .replace('\n', '')
+            lines.append(preamble)
+        lines.append("\\subsubsection*{{RAT}}\n")
+        for q in self.questions:
+            key = solution.answers[q.number - 1]
+            #lines.append(q.write_latex(index, key))
+            lines.append(q.write_latex(q.number, key))
         lines.append("\\end{document}")
         return "".join(lines)
 


### PR DESCRIPTION
When a course is not using Supermark there's no simple way to generate a PDF with a given answer key (to match a RAT created in teampy-s).

This addition allows creating such a PDF without being concerned about which teams exist.