### PR TITLE
Small fixes, improvements, and additional option to export as PDF (with solution)

### DIFF
--- a/docs/export.md
+++ b/docs/export.md
@@ -11,7 +11,7 @@ You can export a RAT so that you can [import it in Blackboard as a test](blackbo
 
     rat export --format blackboard --solution abcdabcdab questions.txt
 
-You need to provide the solution string to shuffle the answer alternatives. 
+You can provide the solution string to shuffle the answer alternatives, or it will be randomly generated for you. 
 
 
 
@@ -21,4 +21,14 @@ You can export a RAT so that you can import it in [Supermark](https://falkr.gith
 
     rat export --format supermark --solution abcdabcdab questions.txt
 
-You need to provide the solution string to shuffle the answer alternatives. 
+You can provide the solution string to shuffle the answer alternatives, or it will be randomly generated for you. 
+
+
+
+## Exporting to PDF
+
+You can export a RAT so that you can use it as a simple PDF document.
+
+    rat export --format pdf --solution abcdabcdab questions.txt
+
+You can provide the solution string to shuffle the answer alternatives, or it will be randomly generated for you. 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.10",
     ],
     entry_points={
         "console_scripts": [

--- a/teampy/core.py
+++ b/teampy/core.py
@@ -375,11 +375,34 @@ class Questionaire:
             preamble = myfile.read()  # .replace('\n', '')
             lines.append(preamble)
         lines.append("\\subsubsection*{{RAT Test Run}}\n")
-        index = 0
+#        index = 0
         for q in self.questions:
-            index += 1
+#            index += 1
             key = random.choice(["a", "b", "c", "d"])
-            lines.append(q.write_latex(index, key))
+#            lines.append(q.write_latex(index, key))
+            lines.append(q.write_latex(q.number, key))
+        lines.append("\\end{document}")
+        return "".join(lines)
+
+    def write_pdf(self, solution):
+        lines = []
+        # add latex preamble
+        # abs_file_path = os.path.join(os.path.dirname(__file__), 'resources', 'latex_preamble.tex')
+        abs_file_path = os.path.join(os.path.dirname(__file__), "latex_preamble.tex")
+        with open(abs_file_path, "r", encoding="utf-8") as myfile:
+            preamble = myfile.read()  # .replace('\n', '')
+            lines.append(preamble)
+        # lines.append("\\subsubsection*{{RAT}}\n")
+        lines.append("\\vbox{\\textbf"
+                     + "{{{}}}".format(self.title)
+                     + "}\n")
+        if len(self.questions) > len(solution.answers):
+            raise Exception("You must provide enough solutions. There are more questions than answers!")
+
+        for q in self.questions:
+            key = solution.answers[q.number - 1]
+            #lines.append(q.write_latex(index, key))
+            lines.append(q.write_latex(q.number, key))
         lines.append("\\end{document}")
         return "".join(lines)
 
@@ -842,7 +865,8 @@ class ResultLine:
                 )
                 return False
         # check that checksum is correct, and that it corresponds with result string
-        if self.type is "student":
+        # if self.type is "student":
+        if self.type == "student":
             if len(self.checksum) != 4:
                 tell(
                     "File {}, line {}: The checksum for student with id {}{} is wrong.".format(
@@ -899,7 +923,19 @@ class ResultLine:
         for c in self.normalized_results.values():
             if c == "a":
                 correct_answers += 1
-        self.score = 100 * correct_answers / len(self.normalized_results)
+# original        self.score = 100 * correct_answers / len(self.normalized_results)
+        if self.type == "student":
+            self.score = 100 * correct_answers / len(self.normalized_results)
+        elif self.type == "team":
+            total_qs = len(self.normalized_results)
+            # using the checksum as the number of attempts
+            attempts = int(self.checksum)
+            # we assume each team got all the correct answers
+            # and count the "extra" attempts to penalise the score
+            # instead of counting only the ones right on the first attempt
+            # NOTE: this assumes 4 possible options 
+            total_choices = 4
+            self.score = 100 - (attempts - total_qs) * (100/total_qs) / (total_choices - 1)
 
         # print('--Results for {}'.format(self.result_id))
         # print('              {}'.format(self.result))

--- a/teampy/latex_preamble.tex
+++ b/teampy/latex_preamble.tex
@@ -118,7 +118,7 @@ Team: & \textbf{#3} \\
 \begin{itemize}\setlength\itemsep{-0.5em}
 \item Select \textbf{one} answer alternative for each question.
 \item Select the answer alternative that matches \textbf{best}.
-\item No helping material is allowed.
+\item \textbf{1 handwritten page} is allowed (no calculators).
 \item Only write within the answer box.
 \end{itemize}
 %


### PR DESCRIPTION
It can be helpful to export a simple PDF with a given randomised solution (for example for online RATs where instead of having a supermark page one wants to share a PDF).

In addition, the following fixes have been incorporated:
- Close the progress bar only if it is initiated (when sending emails)
- Not printing solutions for 10 questions if there are fewer
- tRAT score is no longer binary (0 or 100), it gives more credit to solutions that require fewer attempts 
- Minor typos