### PR TITLE
Explicit import of letltxmacro necessary for newer texlive versions

### DIFF
--- a/teampy/latex_preamble.tex
+++ b/teampy/latex_preamble.tex
@@ -72,6 +72,8 @@
     innerleftmargin=10pt,
     backgroundcolor=white}
 
+\usepackage{letltxmacro}
+
 \LetLtxMacro{\OldIncludegraphics}{\includegraphics}
 \renewcommand{\includegraphics}[2][]{\OldIncludegraphics[width=\linewidth, #1]{#2}}
 \renewcommand{\caption}{}


### PR DESCRIPTION
Ran into this during a fresh install on a colleague's machine. Also encountered by PalmaITEM previously https://github.com/PalmaITEM/teampy/commit/b6b89a72407d9cc4a244b5be9716c8857a2602ed
